### PR TITLE
build: Include str_cat.h for absl:StrCat

### DIFF
--- a/tink/daead/aes_siv_parameters.cc
+++ b/tink/daead/aes_siv_parameters.cc
@@ -18,6 +18,8 @@
 
 #include <set>
 
+#include "absl/strings/str_cat.h"
+
 namespace crypto {
 namespace tink {
 

--- a/tink/daead/failing_daead.cc
+++ b/tink/daead/failing_daead.cc
@@ -19,6 +19,8 @@
 #include <string>
 #include <utility>
 
+#include "absl/strings/str_cat.h"
+
 namespace crypto {
 namespace tink {
 namespace {

--- a/tink/hybrid/failing_hybrid.cc
+++ b/tink/hybrid/failing_hybrid.cc
@@ -19,6 +19,7 @@
 #include <string>
 #include <utility>
 
+#include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "tink/hybrid_encrypt.h"
 

--- a/tink/prf/failing_prfset.cc
+++ b/tink/prf/failing_prfset.cc
@@ -20,6 +20,8 @@
 #include <string>
 #include <utility>
 
+#include "absl/strings/str_cat.h"
+
 namespace crypto {
 namespace tink {
 namespace {

--- a/tink/signature/failing_signature.cc
+++ b/tink/signature/failing_signature.cc
@@ -19,6 +19,7 @@
 #include <string>
 #include <utility>
 
+#include "absl/strings/str_cat.h"
 #include "tink/public_key_sign.h"
 #include "tink/public_key_verify.h"
 

--- a/tink/subtle/streaming_mac_impl.cc
+++ b/tink/subtle/streaming_mac_impl.cc
@@ -23,6 +23,7 @@
 
 #include "absl/memory/memory.h"
 #include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
 #include "openssl/crypto.h"
 #include "tink/util/status.h"
 


### PR DESCRIPTION
Include the header file for absl:StrCar usage to make sure it builds properly with newer version of abseil.