### PR TITLE
Fix C++17 Windows issue when comparing invalid absl::string_view iterators

### DIFF
--- a/tink/internal/util.cc
+++ b/tink/internal/util.cc
@@ -35,28 +35,16 @@ absl::string_view EnsureStringNonNull(absl::string_view str) {
 
 bool BuffersOverlap(absl::string_view first, absl::string_view second) {
   // first begins within second's buffer.
-  bool first_begins_in_second =
-      std::less_equal<absl::string_view::const_iterator>{}(second.begin(),
-                                                           first.begin()) &&
-      std::less<absl::string_view::const_iterator>{}(first.begin(),
-                                                     second.end());
+  const bool first_begins_in_second = first.data() >= second.data() && first.data() < second.data() + second.size();
 
   // second begins within first's buffer.
-  bool second_begins_in_first =
-      std::less_equal<absl::string_view::const_iterator>{}(first.begin(),
-                                                           second.begin()) &&
-      std::less<absl::string_view::const_iterator>{}(second.begin(),
-                                                     first.end());
+  const bool second_begins_in_first = second.data() >= first.data() && second.data() < first.data() + first.size();
 
   return first_begins_in_second || second_begins_in_first;
 }
 
 bool BuffersAreIdentical(absl::string_view first, absl::string_view second) {
-  return !first.empty() && !second.empty() &&
-         std::equal_to<absl::string_view::const_iterator>{}(first.begin(),
-                                                            second.begin()) &&
-         std::equal_to<absl::string_view::const_iterator>{}(
-             std::prev(first.end()), std::prev(second.end()));
+  return !first.empty() && !second.empty() && first.data() == second.data() && first.size() == second.size();
 }
 
 bool IsPrintableAscii(absl::string_view input) {


### PR DESCRIPTION
C++17 introduced `std::string_view`, which `absl::string_view` will type alias to if possible. 

<img width="788" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/0cdbdefd-3b79-4eef-bf09-a829ce557e0b">

On Windows, the `const_iterator` alias refers to a `_String_view_iterator`, which may contain assertions in its comparison operators that ensure the iterators come from the same `std::string_view`. 


<img width="788" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/41328363-a2d2-437b-bae1-cb5109c20946">

<img width="788" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/453e4fec-9ed7-4556-a8c6-13b59e92e6b7">

This behavior differs from the non-aliased `absl::string_view` implementation, and other compiler implementations which simply use char pointers for the iterators, which contain no assertions.

(Abseil implementation)
<img width="423" alt="ABSL_NAMESPACE_BEGIN" src="https://github.com/user-attachments/assets/6e0b98f7-e878-4ffa-8220-7bd7242fb172">

 Tink compares the iterators from different `std::string_view`s, which will trigger the assertion on windows, when the raw pointers from the `std::string_view`s should be compared instead, since this is what the library is basically doing anyways.

One can run the example code in [this repository](https://github.com/RyanLuMaye/TinkExample) built with MSVC to see the runtime assertion failure.
- [x] I have signed the Google Individual Contributor License Agreement