### PR TITLE
Add CMake install/export support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ option(TINK_USE_INSTALLED_ABSEIL "Build Tink linking to Abseil installed in the 
 option(TINK_USE_INSTALLED_GOOGLETEST "Build Tink linking to GTest installed in the system" OFF)
 option(TINK_USE_INSTALLED_PROTOBUF "Build Tink linking to Protobuf installed in the system" OFF)
 option(USE_ONLY_FIPS "Enables the FIPS only mode in Tink" OFF)
+option(TINK_INSTALL "Generate install rules for Tink" OFF)
 
 set(CPACK_GENERATOR TGZ)
 set(CPACK_PACKAGE_VERSION ${PROJECT_VERSION})
@@ -62,3 +63,89 @@ list(APPEND TINK_INCLUDE_DIRS "${TINK_INCLUDE_ALIAS_DIR}")
 
 add_subdirectory(tink)
 add_subdirectory(proto)
+
+if(TINK_INSTALL)
+  include(GNUInstallDirs)
+  include(CMakePackageConfigHelpers)
+
+  if(NOT TINK_USE_SYSTEM_OPENSSL)
+    message(FATAL_ERROR "TINK_INSTALL=ON requires TINK_USE_SYSTEM_OPENSSL=ON")
+  endif()
+  if(NOT TINK_USE_INSTALLED_ABSEIL)
+    message(FATAL_ERROR "TINK_INSTALL=ON requires TINK_USE_INSTALLED_ABSEIL=ON")
+  endif()
+  if(NOT TINK_USE_INSTALLED_PROTOBUF)
+    message(FATAL_ERROR "TINK_INSTALL=ON requires TINK_USE_INSTALLED_PROTOBUF=ON")
+  endif()
+
+  get_property(_tink_all_targets GLOBAL PROPERTY TINK_ALL_TARGETS)
+
+  install(
+    TARGETS ${_tink_all_targets}
+    EXPORT tinkTargets
+    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+  )
+
+  # Install source headers preserving directory structure.
+  install(DIRECTORY tink/
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/tink"
+    FILES_MATCHING PATTERN "*.h"
+  )
+
+  # Install generated proto headers.
+  install(DIRECTORY "${TINK_GENFILE_DIR}/proto/"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/proto"
+    FILES_MATCHING PATTERN "*.pb.h"
+  )
+
+  # Install generated version.h.
+  install(FILES "${TINK_GENFILE_DIR}/tink/version.h"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/tink"
+  )
+
+  # Export set.
+  install(EXPORT tinkTargets
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/tink"
+  )
+
+  # Generate aliases file that recreates tink::module::name aliases
+  # and the tink::static convenience alias.
+  get_property(_tink_alias_map GLOBAL PROPERTY TINK_ALIAS_MAP)
+  set(_aliases_content "# Auto-generated alias targets for tink-cc.\n")
+  foreach(_pair IN LISTS _tink_alias_map)
+    string(REPLACE "=" ";" _kv "${_pair}")
+    list(GET _kv 0 _alias)
+    list(GET _kv 1 _real)
+    string(APPEND _aliases_content
+      "if(TARGET ${_real} AND NOT TARGET ${_alias})\n"
+      "  add_library(${_alias} ALIAS ${_real})\n"
+      "endif()\n")
+  endforeach()
+  string(APPEND _aliases_content
+    "if(TARGET tink_core_cc AND NOT TARGET tink::static)\n"
+    "  add_library(tink::static ALIAS tink_core_cc)\n"
+    "endif()\n")
+  file(GENERATE
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/tinkAliases.cmake"
+    CONTENT "${_aliases_content}")
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/tinkAliases.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/tink")
+
+  # Package version file.
+  write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/tinkConfigVersion.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion)
+
+  # Package config file.
+  configure_package_config_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/tinkConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/tinkConfig.cmake"
+    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/tink")
+
+  install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/tinkConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/tinkConfigVersion.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/tink")
+endif()

--- a/cmake/TinkBuildRules.cmake
+++ b/cmake/TinkBuildRules.cmake
@@ -33,6 +33,7 @@
 # defined by calls to tink_module(). Please don't alter it directly.
 
 include(CMakeParseArguments)
+include(GNUInstallDirs)
 
 # We currently explicitly declare our libraries static below (in add_library).
 # We might remove this, but I'm not confident enough in how this works to
@@ -69,6 +70,15 @@ endif()
 list(APPEND TINK_INCLUDE_DIRS "${TINK_GENFILE_DIR}")
 
 set(TINK_IDE_FOLDER "Tink")
+
+# Global properties for tracking targets to install.
+define_property(GLOBAL PROPERTY TINK_ALL_TARGETS
+  BRIEF_DOCS "All non-test Tink library targets for installation")
+set_property(GLOBAL PROPERTY TINK_ALL_TARGETS "")
+
+define_property(GLOBAL PROPERTY TINK_ALIAS_MAP
+  BRIEF_DOCS "List of alias=real target name pairs")
+set_property(GLOBAL PROPERTY TINK_ALIAS_MAP "")
 
 set(TINK_TARGET_EXCLUDE_IF_BORINGSSL "exclude_if_boringssl")
 set(TINK_TARGET_EXCLUDE_IF_OPENSSL "exclude_if_openssl")
@@ -166,7 +176,14 @@ function(tink_cc_library)
   if(NOT _is_headers_only_lib)
     add_library(${_target_name} STATIC "")
     target_sources(${_target_name} PRIVATE ${tink_cc_library_SRCS})
-    target_include_directories(${_target_name} PUBLIC ${TINK_INCLUDE_DIRS})
+    foreach(_tink_inc_dir IN LISTS TINK_INCLUDE_DIRS)
+      target_include_directories(${_target_name} PUBLIC
+        "$<BUILD_INTERFACE:${_tink_inc_dir}>")
+    endforeach()
+    if(TINK_INSTALL)
+      target_include_directories(${_target_name} PUBLIC
+        "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
+    endif()
     target_link_libraries(${_target_name} PUBLIC ${tink_cc_library_DEPS})
     target_compile_options(${_target_name} PRIVATE ${TINK_DEFAULT_COPTS})
     set_property(TARGET ${_target_name} PROPERTY CXX_STANDARD ${TINK_CXX_STANDARD})
@@ -180,12 +197,26 @@ function(tink_cc_library)
     endif()
   else()
     add_library(${_target_name} INTERFACE)
-    target_include_directories(${_target_name} INTERFACE ${TINK_INCLUDE_DIRS})
+    foreach(_tink_inc_dir IN LISTS TINK_INCLUDE_DIRS)
+      target_include_directories(${_target_name} INTERFACE
+        "$<BUILD_INTERFACE:${_tink_inc_dir}>")
+    endforeach()
+    if(TINK_INSTALL)
+      target_include_directories(${_target_name} INTERFACE
+        "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
+    endif()
     target_link_libraries(${_target_name} INTERFACE ${tink_cc_library_DEPS})
   endif()
 
   add_library(
     tink::${TINK_MODULE}::${tink_cc_library_NAME} ALIAS ${_target_name})
+
+  # Track target for installation.
+  if(NOT tink_cc_library_TESTONLY)
+    set_property(GLOBAL APPEND PROPERTY TINK_ALL_TARGETS "${_target_name}")
+    set_property(GLOBAL APPEND PROPERTY TINK_ALIAS_MAP
+      "tink::${TINK_MODULE}::${tink_cc_library_NAME}=${_target_name}")
+  endif()
 endfunction(tink_cc_library)
 
 # Declare a Tink test using googletest, with a syntax similar to Bazel.

--- a/cmake/TinkWorkspace.cmake
+++ b/cmake/TinkWorkspace.cmake
@@ -114,8 +114,20 @@ if (NOT TARGET crypto)
       "$<BUILD_INTERFACE:${boringssl_SOURCE_DIR}/src/include>")
   else()
     # Support for ED25519 was added from 1.1.1.
-    find_package(OpenSSL 1.1.1 REQUIRED)
-    _create_interface_target(crypto OpenSSL::Crypto)
+    # Try CONFIG mode first (finds installed BoringSSL), then fall back to
+    # module mode (finds system OpenSSL).
+    find_package(OpenSSL CONFIG QUIET)
+    if(NOT OpenSSL_FOUND)
+      find_package(OpenSSL 1.1.1 REQUIRED)
+    endif()
+    if(TINK_INSTALL)
+      # Use IMPORTED so the crypto target is not required in the export set.
+      add_library(crypto INTERFACE IMPORTED)
+      set_target_properties(crypto PROPERTIES
+        INTERFACE_LINK_LIBRARIES "OpenSSL::Crypto")
+    else()
+      _create_interface_target(crypto OpenSSL::Crypto)
+    endif()
   endif()
 else()
   message(STATUS "Using an already declared `crypto` target")

--- a/cmake/tinkConfig.cmake.in
+++ b/cmake/tinkConfig.cmake.in
@@ -1,0 +1,24 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+find_dependency(absl REQUIRED)
+find_dependency(Protobuf REQUIRED CONFIG)
+# Try CONFIG mode first (installed BoringSSL), then module mode (system OpenSSL).
+find_package(OpenSSL CONFIG QUIET)
+if(NOT OpenSSL_FOUND)
+  find_dependency(OpenSSL 1.1.1 REQUIRED)
+endif()
+
+# Tink internals reference a plain "crypto" target for the crypto backend.
+# Create it as an interface to OpenSSL::Crypto when not already defined.
+if(NOT TARGET crypto)
+  add_library(crypto INTERFACE IMPORTED)
+  set_target_properties(crypto PROPERTIES
+    INTERFACE_LINK_LIBRARIES "OpenSSL::Crypto")
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/tinkTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/tinkAliases.cmake")
+
+check_required_components(tink)


### PR DESCRIPTION
Add the ability to build tink-cc as a standalone library and produce a CMake package consumable via find_package(tink).  This enables pre-building tink-cc and using it out of the source tree.

Changes:
- cmake/TinkBuildRules.cmake: track all library targets in global properties (TINK_ALL_TARGETS, TINK_ALIAS_MAP) and use BUILD_INTERFACE / INSTALL_INTERFACE generator expressions for include directories.
- cmake/TinkWorkspace.cmake: support CONFIG-mode OpenSSL discovery (for installed BoringSSL) and create crypto target as IMPORTED when TINK_INSTALL is ON to avoid export-set conflicts.
- CMakeLists.txt: add TINK_INSTALL option with full install/export rules for targets, headers, proto headers, version.h, and CMake package config files.
- cmake/tinkConfig.cmake.in: package config template that finds dependencies (absl, Protobuf, OpenSSL) and imports tink targets.