### PR TITLE
Add signature length validation tests for composite ML-DSA verify

### DIFF
--- a/tink/signature/subtle/composite_ml_dsa_verify_boringssl_test.cc
+++ b/tink/signature/subtle/composite_ml_dsa_verify_boringssl_test.cc
@@ -216,6 +216,19 @@ TEST_P(CompositeMlDsaVerifyBoringSslTest, VerifyWithModifiedSignatureFails) {
                               GetLowLevelCryptoAccess());
   ASSERT_THAT(verifier, IsOk());
 
+  // Verify the valid signature works.
+  ASSERT_THAT((*verifier)->Verify(*signature, message), IsOk());
+
+  // Signature too short.
+  std::string too_short_signature =
+      signature->substr(0, signature->size() - 1);
+  EXPECT_THAT((*verifier)->Verify(too_short_signature, message),
+              Not(IsOk()));
+
+  // Signature with trailing bytes appended must be rejected.
+  std::string too_big_signature = *signature + "00";
+  EXPECT_THAT((*verifier)->Verify(too_big_signature, message), Not(IsOk()));
+
   // Invalidate one byte of the signature.
   (*signature)[10] ^= 1;
   EXPECT_THAT((*verifier)->Verify(*signature, message), Not(IsOk()));


### PR DESCRIPTION
## Summary

The composite ML-DSA signature verification (`composite_ml_dsa_verify_boringssl.cc:178`) uses a less-than check (`<`) for the signature size, which only rejects signatures that are too short. This is inconsistent with:

- **SLH-DSA verify** — uses `!=` (exact check), fixed in commit `740f0ca` with the message: *"Before this change, a SLH DSA signature would be accepted even if there was additional data appended to it."*
- **ML-DSA standalone verify** — uses `!=` (exact check) at lines 109 and 192

The composite verify at line 199 passes all remaining bytes after the ML-DSA signature to the classical verifier:
```cpp
absl::string_view classical_signature =
    signature.substr(output_prefix_size + ml_dsa_signature_size);
```

This means any trailing bytes appended after the classical signature become part of the classical signature input. While the inner classical verifiers (Ed25519, ECDSA, RSA) currently enforce exact signature lengths and reject trailing data, the composite layer's security contract should not depend on inner verifier implementation details.

This PR adds test cases for signature length validation (too short, too long), matching the test pattern added for SLH-DSA in commit `740f0ca`.

## Affected code

- `tink/signature/subtle/composite_ml_dsa_verify_boringssl.cc:178` — uses `<` instead of appropriate exact-length enforcement

## Impact

Signature malleability: given a valid composite ML-DSA signature, a different byte string (with appended trailing data) could pass verification. Currently mitigated by inner verifiers, but the composite layer should enforce this independently.

## Test plan

- [x] Added test for "signature too short" — should fail verification
- [x] Added test for "signature with trailing bytes" — should fail verification (currently relies on inner verifier rejection)