### PR TITLE
Check SLHDSA_SHA2_128S_sign return value in SLH-DSA sign

### DIFF
--- a/tink/signature/internal/slh_dsa_sign_boringssl.cc
+++ b/tink/signature/internal/slh_dsa_sign_boringssl.cc
@@ -73,19 +73,25 @@ absl::StatusOr<std::string> SlhDsaSignBoringSsl::Sign(
       SLHDSA_SHA2_128S_SIGNATURE_BYTES + private_key_.GetOutputPrefix().size();
   subtle::ResizeStringUninitialized(&signature, signature_buffer_size);
 
-  internal::CallWithCoreDumpProtection([&]() {
+  absl::Status status = internal::CallWithCoreDumpProtection([&]() {
     internal::ScopedAssumeRegionCoreDumpSafe scope(&signature[0],
                                                    signature_buffer_size);
-    SLHDSA_SHA2_128S_sign(
-        reinterpret_cast<uint8_t *>(&signature[0] +
-                                    private_key_.GetOutputPrefix().size()),
-        private_key_.GetPrivateKeyBytes(GetPartialKeyAccess())
-            .Get(InsecureSecretKeyAccess::Get())
-            .data(),
-        reinterpret_cast<const uint8_t *>(data.data()), data.size(),
-        /* context = */ nullptr, /* context_len = */ 0);
+    if (!SLHDSA_SHA2_128S_sign(
+            reinterpret_cast<uint8_t *>(&signature[0] +
+                                        private_key_.GetOutputPrefix().size()),
+            private_key_.GetPrivateKeyBytes(GetPartialKeyAccess())
+                .Get(InsecureSecretKeyAccess::Get())
+                .data(),
+            reinterpret_cast<const uint8_t *>(data.data()), data.size(),
+            /* context = */ nullptr, /* context_len = */ 0)) {
+      return absl::InternalError("Failed to generate SLH-DSA signature.");
+    }
     internal::DfsanClearLabel(&signature[0], signature_buffer_size);
+    return absl::OkStatus();
   });
+  if (!status.ok()) {
+    return status;
+  }
 
   return signature;
 }


### PR DESCRIPTION
## Summary

`SlhDsaSignBoringSsl::Sign` (`slh_dsa_sign_boringssl.cc:79`) does not check the return value of `SLHDSA_SHA2_128S_sign`, which returns `int` (0 on failure, 1 on success per BoringSSL's `include/openssl/slhdsa.h`).

If the signing operation fails, the function returns a buffer of uninitialized memory as the "signature" — the buffer was allocated with `ResizeStringUninitialized` on line 74.

This is inconsistent with:
- **ML-DSA sign** (`ml_dsa_sign_boringssl.cc:126-133`) — correctly checks `if (!MLDSA65_sign(...)) { return InternalError; }`
- **Commit `0f1fe03`** — fixed the same pattern in `EciesHkdfX25519SendKemBoringSsl::GenerateKey`

## Impact

If `SLHDSA_SHA2_128S_sign` returns 0 (e.g., due to RNG failure), Tink returns an uninitialized memory buffer as a valid `StatusOr<string>`. This is:
1. Potential uninitialized memory disclosure (the "signature" contains heap garbage)
2. Silent signing failure (caller thinks signing succeeded)

## Fix

Follow the ML-DSA sign pattern: capture `CallWithCoreDumpProtection` return status, check `SLHDSA_SHA2_128S_sign` return value inside the lambda, propagate errors.

## Test plan

- Existing SLH-DSA sign tests continue to pass (signing with valid keys still works)
- The failure path (RNG failure) cannot be easily triggered in a unit test without mocking BoringSSL internals