### PR TITLE
Reject trailing bytes after CBS parsing in ML-DSA and ML-KEM

### DIFF
--- a/tink/experimental/pqcrypto/kem/internal/ml_kem_raw_encapsulate_boringssl.cc
+++ b/tink/experimental/pqcrypto/kem/internal/ml_kem_raw_encapsulate_boringssl.cc
@@ -83,7 +83,8 @@ MlKemRawEncapsulateBoringSsl::New(MlKemPublicKey recipient_key) {
   CBS_init(&cbs, reinterpret_cast<const uint8_t*>(public_key_bytes.data()),
            public_key_bytes.size());
   auto public_key = std::make_unique<MLKEM768_public_key>();
-  if (!MLKEM768_parse_public_key(public_key.get(), &cbs)) {
+  if (!MLKEM768_parse_public_key(public_key.get(), &cbs) ||
+      CBS_len(&cbs) != 0) {
     return absl::Status(absl::StatusCode::kInternal,
                         "Invalid ML-KEM public key");
   }

--- a/tink/signature/internal/ml_dsa_verify_boringssl.cc
+++ b/tink/signature/internal/ml_dsa_verify_boringssl.cc
@@ -94,7 +94,8 @@ absl::StatusOr<std::unique_ptr<PublicKeyVerify>> MlDsa65VerifyBoringSsl::New(
   CBS_init(&cbs, reinterpret_cast<const uint8_t*>(public_key_bytes.data()),
            public_key_bytes.size());
   auto boringssl_public_key = std::make_unique<MLDSA65_public_key>();
-  if (!MLDSA65_parse_public_key(boringssl_public_key.get(), &cbs)) {
+  if (!MLDSA65_parse_public_key(boringssl_public_key.get(), &cbs) ||
+      CBS_len(&cbs) != 0) {
     return absl::InternalError("Invalid ML-DSA public key");
   }
 
@@ -177,7 +178,8 @@ absl::StatusOr<std::unique_ptr<PublicKeyVerify>> MlDsa87VerifyBoringSsl::New(
   CBS_init(&cbs, reinterpret_cast<const uint8_t*>(public_key_bytes.data()),
            public_key_bytes.size());
   auto boringssl_public_key = std::make_unique<MLDSA87_public_key>();
-  if (!MLDSA87_parse_public_key(boringssl_public_key.get(), &cbs)) {
+  if (!MLDSA87_parse_public_key(boringssl_public_key.get(), &cbs) ||
+      CBS_len(&cbs) != 0) {
     return absl::InternalError("Invalid ML-DSA public key");
   }
 


### PR DESCRIPTION
## Summary

After calling `MLDSA65_parse_public_key`, `MLDSA87_parse_public_key`, and `MLKEM768_parse_public_key` via CBS, the code does not check `CBS_len(&cbs) != 0` to ensure no trailing bytes remain in the CBS buffer.

This is inconsistent with the existing X-Wing implementation at `xwing_util.cc:76-77`:
```cpp
if (!XWING_parse_private_key(&xwing_private_key, &cbs) ||
    CBS_len(&cbs) != 0) {  // <-- trailing bytes check
```

## Affected files

- `tink/signature/internal/ml_dsa_verify_boringssl.cc:97` (ML-DSA-65)
- `tink/signature/internal/ml_dsa_verify_boringssl.cc:180` (ML-DSA-87)
- `tink/experimental/pqcrypto/kem/internal/ml_kem_raw_encapsulate_boringssl.cc:86` (ML-KEM-768)

## Impact

Without this check, a public key with trailing garbage bytes after the valid key data is silently accepted. While the Tink key creation path (`MlKemPublicKey::Create`, `MlDsaPublicKey::Create`) validates exact key sizes, this adds defense-in-depth at the BoringSSL interface layer, consistent with the existing X-Wing implementation.

## Test plan

- Existing ML-DSA and ML-KEM tests pass unchanged (valid keys have no trailing bytes)