### PR TITLE
fix: add plaintext size validation in AES-EAX Encrypt

### DIFF
--- a/tink/subtle/aes_eax_boringssl.cc
+++ b/tink/subtle/aes_eax_boringssl.cc
@@ -246,9 +246,14 @@ absl::StatusOr<std::string> AesEaxBoringSsl::Encrypt(
   plaintext = internal::EnsureStringNonNull(plaintext);
   associated_data = internal::EnsureStringNonNull(associated_data);
 
-  size_t ciphertext_size = plaintext.size() + nonce_size_ + kTagSize;
+  int64_t ciphertext_size =
+      static_cast<int64_t>(plaintext.size()) + nonce_size_ + kTagSize;
+  if (ciphertext_size < 0 ||
+      ciphertext_size > static_cast<int64_t>(std::string().max_size())) {
+    return absl::InvalidArgumentError("Plaintext too long");
+  }
   std::string ciphertext;
-  ResizeStringUninitialized(&ciphertext, ciphertext_size);
+  ResizeStringUninitialized(&ciphertext, static_cast<size_t>(ciphertext_size));
   return internal::CallWithCoreDumpProtection(
       [&]() -> absl::StatusOr<std::string> {
         // The ciphertext region is allowed to leak: this never fails and


### PR DESCRIPTION
## Summary

The ciphertext size calculation in `AesEaxBoringSsl::Encrypt` uses `size_t` arithmetic:

```cpp
size_t ciphertext_size = plaintext.size() + nonce_size_ + kTagSize;
```

If `plaintext.size()` is close to `SIZE_MAX`, this wraps around to a small value, causing `ResizeStringUninitialized` to allocate a tiny buffer. Subsequent writes (CTR encryption, nonce copy, tag copy) would then write beyond the buffer.

### Fix

Use `int64_t` for the size calculation with an explicit overflow check, consistent with the pattern used by other AEAD implementations (e.g., `ssl_aead.cc` uses `int64_t` for `CiphertextSize()`).

### Impact

Low in practice — allocating a buffer close to `SIZE_MAX` bytes would typically fail before reaching the overflow. However, this is a defense-in-depth gap that deviates from the pattern established by other AEAD implementations in the same codebase.