### PR TITLE
fix: use SafeCryptoMemEquals for AES-EAX tag verification

### DIFF
--- a/tink/subtle/aes_eax_boringssl.cc
+++ b/tink/subtle/aes_eax_boringssl.cc
@@ -38,6 +38,7 @@
 #include "tink/internal/call_with_core_dump_protection.h"
 #include "tink/internal/dfsan_forwarders.h"
 #include "tink/internal/fips_utils.h"
+#include "tink/internal/safe_stringops.h"
 #include "tink/internal/secret_buffer.h"
 #include "tink/internal/util.h"
 #include "tink/subtle/random.h"
@@ -122,13 +123,6 @@ void AesEaxBoringSsl::MultiplyByX(const uint8_t in[kBlockSize],
   uint64_t out_low = (in_low << 1) ^ (0x87 & -(in_high >> 63));
   BigEndianStore64(out_high, out);
   BigEndianStore64(out_low, out + 8);
-}
-
-bool AesEaxBoringSsl::EqualBlocks(const uint8_t x[kBlockSize],
-                                  const uint8_t y[kBlockSize]) {
-  uint64_t res = Load64(x) ^ Load64(y);
-  res |= Load64(x + 8) ^ Load64(y + 8);
-  return res == 0;
 }
 
 bool AesEaxBoringSsl::IsValidKeySize(size_t key_size_in_bytes) {
@@ -301,7 +295,7 @@ absl::StatusOr<std::string> AesEaxBoringSsl::Decrypt(
         XorBlock(N.data(), &mac);
         XorBlock(H.data(), &mac);
         const uint8_t* sig = reinterpret_cast<const uint8_t*>(tag.data());
-        if (!EqualBlocks(mac.data(), sig)) {
+        if (!internal::SafeCryptoMemEquals(mac.data(), sig, kBlockSize)) {
           return absl::Status(absl::StatusCode::kInvalidArgument,
                               "Tag mismatch");
         }

--- a/tink/subtle/aes_eax_boringssl.h
+++ b/tink/subtle/aes_eax_boringssl.h
@@ -91,9 +91,6 @@ class AesEaxBoringSsl : public Aead {
   static void MultiplyByX(const uint8_t in[kBlockSize],
                           uint8_t out[kBlockSize]);
 
-  // Constant-time block equality
-  static bool EqualBlocks(const uint8_t x[kBlockSize],
-                          const uint8_t y[kBlockSize]);
 
   // Encrypts a single block with AES.
   void EncryptBlock(Block* /*absl_nonnull - not yet supported*/ block) const;


### PR DESCRIPTION
## Summary

- Replace hand-rolled `EqualBlocks` XOR+OR comparison with `SafeCryptoMemEquals` (wrapping `CRYPTO_memcmp`) for AEAD authentication tag verification in AES-EAX decrypt
- Remove now-unused `EqualBlocks` method from `AesEaxBoringSsl`
- AES-EAX was the **only** AEAD primitive in Tink not using `SafeCryptoMemEquals` for tag comparison

## Motivation

All other AEAD and MAC implementations in Tink use `SafeCryptoMemEquals` for authentication tag verification:

| Primitive | File | Comparison |
|-----------|------|------------|
| AES-SIV | `aes_siv_boringssl.cc:294` | `SafeCryptoMemEquals` |
| HMAC | `hmac_boringssl.cc:125` | `SafeCryptoMemEquals` |
| AES-CMAC | `aes_cmac_boringssl.cc:173` | `SafeCryptoMemEquals` |
| Streaming MAC | `streaming_mac_impl.cc:189` | `SafeCryptoMemEquals` |
| Chunked MAC | `chunked_mac_impl.cc:87` | `SafeCryptoMemEquals` |
| **AES-EAX** | `aes_eax_boringssl.cc:304` | ~~`EqualBlocks`~~ → `SafeCryptoMemEquals` |

The hand-rolled XOR+OR pattern in `EqualBlocks` is not guaranteed to be constant-time by the C++ standard. While current GCC on x86-64 generates constant-time SSE code, this is not guaranteed across other compilers (MSVC, Clang), architectures (ARM, RISC-V), or with LTO/PGO optimizations. `CRYPTO_memcmp` uses explicit barriers to prevent compiler optimizations.

## Test plan

- [x] Existing `AesEaxBoringSslTest` tests pass (no behavioral change — both functions return the same boolean result for equal/unequal blocks)
- [x] Verified `SafeCryptoMemEquals` wraps `CRYPTO_memcmp` which is the standard constant-time comparison primitive