### PR TITLE
Reject trailing data after the last segment in StreamingAeadDecryptingStream

### DIFF
--- a/tink/subtle/streaming_aead_decrypting_stream.cc
+++ b/tink/subtle/streaming_aead_decrypting_stream.cc
@@ -76,6 +76,19 @@ absl::Status ReadFromStream(InputStream* input_stream, int count,
   return absl::OkStatus();
 }
 
+// Returns OK if 'input_stream' is exhausted, i.e. the ciphertext ended with
+// the last segment; returns INVALID_ARGUMENT if unauthenticated trailing data
+// follows the last segment.
+absl::Status VerifyEndOfStream(InputStream* input_stream) {
+  std::vector<uint8_t> trailing_data;
+  absl::Status status = ReadFromStream(input_stream, 1, &trailing_data);
+  if (status.code() == absl::StatusCode::kOutOfRange) return absl::OkStatus();
+  if (!status.ok()) return status;
+  return absl::Status(
+      absl::StatusCode::kInvalidArgument,
+      "Ciphertext contains trailing data after the last segment.");
+}
+
 }  // anonymous namespace
 
 // static
@@ -148,6 +161,7 @@ absl::StatusOr<int> StreamingAeadDecryptingStream::Next(const void** data) {
           /* segment_number = */ segment_number_,
           /* is_last_segment = */ read_last_segment_,
           &pt_buffer_);
+      if (status_.ok()) status_ = VerifyEndOfStream(ct_source_.get());
     }
     if (!status_.ok()) return status_;
     *data = pt_buffer_.data();
@@ -192,6 +206,7 @@ absl::StatusOr<int> StreamingAeadDecryptingStream::Next(const void** data) {
         /* segment_number = */ segment_number_,
         /* is_last_segment = */ read_last_segment_,
         &pt_buffer_);
+    if (status_.ok()) status_ = VerifyEndOfStream(ct_source_.get());
   }
   if (!status_.ok()) return status_;
   *data = pt_buffer_.data();

--- a/tink/subtle/streaming_aead_decrypting_stream_test.cc
+++ b/tink/subtle/streaming_aead_decrypting_stream_test.cc
@@ -264,6 +264,47 @@ TEST_F(StreamingAeadDecryptingStreamTest, OneSegmentAndOneBytePlaintext) {
   EXPECT_EQ(absl::StatusCode::kOutOfRange, next_result.status().code());
 }
 
+TEST_F(StreamingAeadDecryptingStreamTest, TrailingDataAfterLastSegmentRejected) {
+  int pt_segment_size = 512;
+  int header_size = 64;
+
+  // Plaintext sizes whose ciphertext ends with an exactly full last segment:
+  // a single full segment, and two full segments.
+  for (int pt_size : {pt_segment_size - header_size,
+                      2 * pt_segment_size - header_size}) {
+    SCOPED_TRACE(absl::StrCat("pt_size = ", pt_size));
+    std::string pt = Random::GetRandomBytes(pt_size);
+    DummyStreamSegmentEncrypter seg_enc(pt_segment_size, header_size,
+        /* ct_offset = */ 0);
+    std::string ct = seg_enc.GenerateCiphertext(pt);
+    ASSERT_EQ(0, ct.size() % seg_enc.get_ciphertext_segment_size());
+
+    // The unmodified ciphertext still decrypts.
+    ValidationRefs refs;
+    auto dec_stream = GetDecryptingStream(pt_segment_size, header_size,
+        /* ct_offset = */ 0, ct, &refs);
+    std::string decrypted;
+    EXPECT_THAT(test::ReadFromStream(dec_stream.get(), &decrypted), IsOk());
+    EXPECT_EQ(pt, decrypted);
+
+    // Appending unauthenticated trailing data is rejected.
+    for (int trailing_size : {1, seg_enc.get_ciphertext_segment_size()}) {
+      SCOPED_TRACE(absl::StrCat("trailing_size = ", trailing_size));
+      ValidationRefs tampered_refs;
+      auto tampered_stream = GetDecryptingStream(
+          pt_segment_size, header_size, /* ct_offset = */ 0,
+          ct + std::string(trailing_size, 'x'), &tampered_refs);
+      std::string tampered_decrypted;
+      auto status =
+          test::ReadFromStream(tampered_stream.get(), &tampered_decrypted);
+      EXPECT_THAT(status, Not(IsOk()));
+      EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+      EXPECT_PRED_FORMAT2(testing::IsSubstring, "trailing data",
+                          std::string(status.message()));
+    }
+  }
+}
+
 TEST_F(StreamingAeadDecryptingStreamTest, NextAfterBackUp) {
   int pt_segment_size = 97;
   int pt_size = 334;


### PR DESCRIPTION
## Summary

`StreamingAead::NewDecryptingStream` silently accepts a ciphertext with
unauthenticated data appended after the last segment, when the final
ciphertext segment is exactly the full segment size. Decryption returns the
original plaintext and reaches end-of-stream without ever reading,
authenticating, or rejecting the appended bytes.

This addresses the behavior reported in #20.

## Root cause

`StreamingAeadDecryptingStream::Next()` reads exactly one ciphertext segment
and infers whether it is the last segment from whether that read hit
end-of-stream. A full-sized final segment is read without observing EOF, so
it is first attempted as a non-final segment; that fails the last-segment
authentication check, and the code then retries the same segment as the
final segment. The retry path never verifies that the ciphertext source is
exhausted, so any trailing bytes after a full final segment are discarded.

The retry itself is required — a legitimate full-sized final segment is
decrypted the same way — so it cannot simply be removed.

## Fix

After a segment is successfully decrypted as the last segment on the retry
path, verify that the ciphertext source contains no further data, and reject
the ciphertext otherwise. Only the retry path needs the check; when the last
segment is reached by observing end-of-stream, the source is already
exhausted.

This makes the sequential decrypting stream consistent with
`DecryptingRandomAccessStream`, which derives the segment count from the
total ciphertext size and already rejects such inputs.

## Tests

Adds `TrailingDataAfterLastSegmentRejected`, covering both the
single-full-segment and multi-segment (full final segment) paths, each with
one appended byte and with a full appended segment, and asserting that the
unmodified ciphertext still decrypts. All existing streaming-AEAD tests
continue to pass.

Fixes #20.
