### PR TITLE
[FIX] Widen BufferedInputStream counters to int64_t to  prevent overflow

### DIFF
--- a/tink/streamingaead/buffered_input_stream.cc
+++ b/tink/streamingaead/buffered_input_stream.cc
@@ -57,12 +57,12 @@ absl::StatusOr<int> BufferedInputStream::Next(const void** data) {
     after_rewind_ = false;
     *data = buffer_.data();
     position_ = count_in_buffer_;
-    return count_in_buffer_;
+    return static_cast<int>(count_in_buffer_);
   }
   if (count_backedup_ > 0) {  // Return the backed-up bytes.
     buffer_offset_ = count_in_buffer_ - count_backedup_;
     *data = buffer_.data() + buffer_offset_;
-    int backedup = count_backedup_;
+    int backedup = static_cast<int>(count_backedup_);
     count_backedup_ = 0;
     position_ = count_in_buffer_;
     return backedup;
@@ -109,8 +109,8 @@ void BufferedInputStream::BackUp(int count) {
       count_backedup_ == (count_in_buffer_ - buffer_offset_)) {
     return;
   }
-  int actual_count = std::min(
-      count, count_in_buffer_ - buffer_offset_ - count_backedup_);
+  int actual_count = static_cast<int>(std::min<int64_t>(
+      count, count_in_buffer_ - buffer_offset_ - count_backedup_));
   count_backedup_ += actual_count;
   position_ = position_ - actual_count;
 }

--- a/tink/streamingaead/buffered_input_stream.h
+++ b/tink/streamingaead/buffered_input_stream.h
@@ -68,9 +68,9 @@ class BufferedInputStream : public crypto::tink::InputStream {
   int64_t position_;     // current position in the stream (from the beginning)
 
   // Counters that describe the state of the data in buffer_.
-  int count_in_buffer_;  // # of bytes available in buffer_
-  int count_backedup_;   // # of bytes available in buffer_ that were backed up
-  int buffer_offset_;    // offset at which the returned bytes start in buffer_
+  int64_t count_in_buffer_;  // # of bytes available in buffer_
+  int64_t count_backedup_;   // # of bytes available in buffer_ that were backed up
+  int64_t buffer_offset_;    // offset at which the returned bytes start in buffer_
 };
 
 }  // namespace streamingaead


### PR DESCRIPTION
count_in_buffer_, count_backedup_, and buffer_offset_ were declared as int (32-bit signed).  count_in_buffer_ accumulates the total number of bytes ever buffered via count_in_buffer_ += count_read, where count_read is size_t.  Once the accumulated total exceeds INT32_MAX (~2 GiB) the implementation-defined narrowing to int wraps the value to INT_MIN, which is then used as the destination offset in

  memcpy(buffer_.data() + count_in_buffer_, buf, count_read);

producing an out-of-bounds write before the heap allocation.

This is reachable through the streaming-AEAD decryption path when the keyset's ciphertext_segment_size is large (the validation allows up to 0x7fffffff) and the caller supplies >= 2 GiB of ciphertext.  The overflow fires during buffering, before any MAC verification, so no authentication is required.

Widening the three counters to int64_t makes the accumulation safe for any realistic input size.  The return values from Next() are narrowed to int via static_cast to preserve the InputStream::Next() contract.

Bug: 539196044