### PR TITLE
Replace minstd_rand0 with CSPRNG for key-ID generation

### DIFF
--- a/tink/util/BUILD.bazel
+++ b/tink/util/BUILD.bazel
@@ -342,7 +342,10 @@ cc_library(
     srcs = ["keyset_util.cc"],
     hdrs = ["keyset_util.h"],
     include_prefix = "tink/util",
-    deps = ["//proto:tink_cc_proto"],
+    deps = [
+        "//proto:tink_cc_proto",
+        "//tink/subtle:random",
+    ],
 )
 
 cc_library(

--- a/tink/util/CMakeLists.txt
+++ b/tink/util/CMakeLists.txt
@@ -274,6 +274,7 @@ tink_cc_library(
     keyset_util.h
   DEPS
     tink::proto::tink_cc_proto
+    tink::subtle::random
 )
 
 # tests

--- a/tink/util/keyset_util.cc
+++ b/tink/util/keyset_util.cc
@@ -20,6 +20,7 @@
 #include <random>
 
 #include "proto/tink.pb.h"
+#include "tink/subtle/random.h"
 
 namespace crypto {
 namespace tink {
@@ -29,10 +30,7 @@ namespace {
 using google::crypto::tink::Keyset;
 
 uint32_t NewKeyId() {
-  std::random_device rd;
-  std::minstd_rand0 gen(rd());
-  std::uniform_int_distribution<uint32_t> dist;
-  return dist(gen);
+  return subtle::Random::GetRandomUInt32();
 }
 
 }  // namespace


### PR DESCRIPTION
Replaces the non-cryptographic `std::minstd_rand0` (31-bit LCG) used for
keyset key-ID generation with `subtle::Random::GetRandomUInt32()`, backed by
BoringSSL `RAND_bytes`.

`NewKeyId()` feeds `GenerateUnusedKeyId()`, used by `KeysetHandle`, the JWK
set converter, and the PEM keyset reader. Go and Java both use CSPRNGs
(`crypto/rand`, `SecureRandom`); C++ was the outlier with a deterministic LCG
that is predictable once seeded, enabling engineered key-ID collisions.

Also adds the `//tink/subtle:random` (Bazel) and `tink::subtle::random`
(CMake) build dependencies.